### PR TITLE
Drop mandrill usage

### DIFF
--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -64,9 +64,8 @@ def send_multiple(to_list, subject, text=None, data={},
         return None
 
 
-def send_mail(to, subject, text=None, html=None, to_name='',
-              data={}, mandrill_args={'preserve_recipients': False},
-              use_template=None, is_async=False, config=None):
+def send_mail(to, subject, text=None, to_name='',
+              data={}, is_async=False, config=None):
     """ Send out text/HTML email with specified templates """
-    return send_multiple([(to, to_name)], subject, text, html, data,
-                         mandrill_args, use_template, is_async, config)
+    return send_multiple(
+        [(to, to_name)], subject, text, data, is_async, config)

--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -13,7 +13,6 @@ from __future__ import unicode_literals, print_function
 import smtplib
 import logging
 from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 
 from bottle import request, template
 
@@ -42,8 +41,11 @@ def send_multiple(to_list, subject, text=None, data={},
     # context
     conf = config or request.app.config
 
+    # Process the data with the chosen template
+    message = template(text, **data)
+
     # Construct message object
-    msg = MIMEMultipart()  # Special object for building emails
+    msg = MIMEText(message, 'plain', 'utf-8')
     msg['subject'] = subject
     msg['from'] = conf['smtp.user']  # Get sender's email from the config
     # As described in the docstring, we only use the first item in whatever
@@ -52,11 +54,6 @@ def send_multiple(to_list, subject, text=None, data={},
 
     # Add the subject of the email and a newline character
     msg.preamble = subject + '\n'
-
-    # Process the data with the chosen template
-    message = template(text, **data)
-    plain = MIMEText(message, 'plain', 'utf-8')
-    msg.attach(plain)
 
     # Open SMTP connection
     smtp = smtplib.SMTP('%s:%s' % (conf['smtp.server'], conf['smtp.port']))

--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -52,7 +52,8 @@ def send_multiple(to_list, subject, text=None, data={},
     # objects make up the to_list. This is historical, BD (Before Docstrings).
     msg['to'] = ', '.join([e[0] for e in to_list])
 
-    # Add the subject of the email and a newline character
+    # For more information on how preamble is used, see
+    # https://docs.python.org/2/library/email.message.html#email.message.Message.preamble
     msg.preamble = subject + '\n'
 
     # Open SMTP connection

--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -63,7 +63,7 @@ def send_multiple(to_list, subject, text=None, data={},
     smtp.starttls()  # Calls `ehlo` if it hasn't been already
     # Calls `ehlo` if it needs to be, which it does because starttls was called
     smtp.login(conf['smtp.user'], conf['smtp.pass'])
-    try:  # Try to send the message
+    try:
         smtp.sendmail(msg['from'], msg['to'], msg.as_string())
         smtp.quit()
         logging.debug("Sent message to %s" % msg['to'])

--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -57,7 +57,6 @@ def send_multiple(to_list, subject, text=None, data={},
     message = template(text, **data)
     plain = MIMEText(message, 'plain', 'utf-8')
     msg.attach(plain)
-    logging.debug("Prepared message")
 
     # Open SMTP connection
     smtp = smtplib.SMTP('%s:%s' % (conf['smtp.server'], conf['smtp.port']))
@@ -67,6 +66,7 @@ def send_multiple(to_list, subject, text=None, data={},
     try:  # Try to send the message
         smtp.sendmail(msg['from'], msg['to'], msg.as_string())
         smtp.quit()
+        logging.debug("Sent message to %s" % msg['to'])
         return
     except Exception as e:
         smtp.quit()  # smtp connection will stay open until closed

--- a/broadcast/util/sendmail.py
+++ b/broadcast/util/sendmail.py
@@ -34,7 +34,7 @@ def send_multiple(to_list, subject, text=None, data={},
     """
     # As described in the docstring, you must provide a template
     if text is None:
-        with Exception('no template specified') as ex:
+        with ValueError('no template specified') as ex:
             logging.exception('Error sending email: %s' % ex)
         return None
 


### PR DESCRIPTION
This PR replaces mandrill usage with SMTP usage. It has also placed an emphasis on only modifying one module, thus `is_async` has been left as a kwarg. 

Here is a list of places `send_m*` functions are used, without imports and the sendmail module. All arguments used by these function calls are kept.

```
broadcast/util/auth/helpers.py:   send_mail(email,
broadcast/routes/auth.py:         tasks.schedule(send_mail,
broadcast/routes/priority.py:     send_mail(item.email,
broadcast/helpers.py:             send_multiple([(email, email) for email in recipients],
```
