### PR TITLE
Disable twitter

### DIFF
--- a/broadcast/routes/broadcast.py
+++ b/broadcast/routes/broadcast.py
@@ -144,17 +144,5 @@ def route(conf):
             broadcast_content,
             'broadcast_content',
             {}
-        ), (
-            '/broadcast/twitter/',
-            'GET',
-            show_broadcast_twitter_form,
-            'broadcast_twitter_form',
-            {}
-        ), (
-            '/broadcast/twitter/',
-            'POST',
-            broadcast_twitter,
-            'broadcast_twitter',
-            {}
         ),
     )

--- a/broadcast/views/main.tpl
+++ b/broadcast/views/main.tpl
@@ -5,7 +5,6 @@
         <h2>${_('File sharing from space')}</h2>
         <p class="buttons">
             <a class="button" href="${url('broadcast_content_form', item_type='content')}">${_("Share your files")}</a>
-            <a class="button" href="${url('broadcast_twitter_form')}">${_("Share your tweets")}</a>
         </p>
         <p class="blurb">${_("Share your favorite files with the world. Broadcast your blog posts, documents, music, and videos from six geostationary satellites.")}</p>
         <div class="daily-bin">


### PR DESCRIPTION
Removes twitter submissions from front page and disables routes related to twitter.

Twitter should not be accessible, but functions relating to twitter are not destroyed.
