### PR TITLE
Redirect to homepage from registration page if the beta.open_registration flag is not set

### DIFF
--- a/broadcast/broadcast.ini
+++ b/broadcast/broadcast.ini
@@ -15,6 +15,9 @@ secret_key = not-secret
 # Location of the beta whitelist file
 whitelist = /tmp/broadcast-beta-whitelist.txt
 
+# Determines whether anyone can register or just invited users
+open_registration = no
+
 [bin]
 
 # Maximum capacity of a single bin

--- a/broadcast/routes/auth.py
+++ b/broadcast/routes/auth.py
@@ -12,6 +12,7 @@ import logging
 
 from bottle_utils.i18n import dummy_gettext as _
 
+from ..app.exts import container as exts
 from ..models.auth import (
     User,
     EmailVerificationToken,
@@ -126,6 +127,16 @@ class Register(NoLoginNeededMixin, CSRFMixin, ActionXHRPartialFormRoute):
     form_factory = RegisterForm
     success_message = _('Check your inbox for an email confirmation link')
     success_url = ('main:home', {})
+
+    def get(self):
+        if not exts.config['beta.open_registration']:
+            self.redirect(self.get_success_url())
+        return super(Register, self).get()
+
+    def post(self):
+        if not exts.config['beta.open_registration']:
+            self.redirect(self.get_success_url())
+        return super(Register, self).post()
 
 
 class Login(NoLoginNeededMixin, CSRFMixin, NextPathMixin,

--- a/broadcast/routes/auth.py
+++ b/broadcast/routes/auth.py
@@ -128,16 +128,6 @@ class Register(NoLoginNeededMixin, CSRFMixin, ActionXHRPartialFormRoute):
     success_message = _('Check your inbox for an email confirmation link')
     success_url = ('main:home', {})
 
-    def get(self):
-        if not exts.config['beta.open_registration']:
-            self.redirect(self.get_success_url())
-        return super(Register, self).get()
-
-    def post(self):
-        if not exts.config['beta.open_registration']:
-            self.redirect(self.get_success_url())
-        return super(Register, self).post()
-
 
 class Login(NoLoginNeededMixin, CSRFMixin, NextPathMixin,
             ActionXHRPartialFormRoute):
@@ -259,8 +249,7 @@ class Logout(ActionTemplateRoute):
 
 
 def route():
-    return (
-        Register,
+    route_classes = (
         Login,
         ResendConfirmation,
         ConfirmEmail,
@@ -270,3 +259,6 @@ def route():
         NameCheck,
         Logout,
     )
+    if exts.config['beta.open_registration']:
+        route_classes = (Register,) + route_classes
+    return route_classes


### PR DESCRIPTION
Provide means to disable the all-accessible registration page.
