### PR TITLE
Do not use content-disposition header

### DIFF
--- a/broadcast/routes/queue.py
+++ b/broadcast/routes/queue.py
@@ -119,7 +119,6 @@ class Vote(ModeratorOnlyMixin, ActionTemplateRoute):
 
 class Download(ModeratorOnlyMixin, StaticRoute):
     path = '/download/<item_id:re:[0-9a-f]{32}>'
-    force_download = True
 
     def get_base_dirs(self):
         return [exts.config['content.upload_root']]

--- a/broadcast/views/queue/_items.mako
+++ b/broadcast/views/queue/_items.mako
@@ -7,7 +7,7 @@
         ${_('Uploaded by {username} {timeago}').format(username=item.username, timeago=th.human_time(item.created))}
     </p>
     <p class="item-info item-download">
-        <a class="button button-small" href="${url('queue:download', item_id=item.id)}">
+        <a class="button button-small" href="${url('queue:download', item_id=item.id)}" target="_blank">
             <span class="icon icon-download"></span>
             <span class="invisible-label">${_('download')}</span>
             <span class="supplementary-info">${h.hsize(item.size)}</span>


### PR DESCRIPTION
In the item lists, do not use the content-disposition header and allow the
browser to decide whether to render the file or download it.

Fixes #31
